### PR TITLE
[demo: do not merge] Demonstrate end-to-end coverage of .ts files using istanbul v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint src/**/*.ts",
     "build": "rm -rf dist/ && tsc",
     "test-spec": "ts-node node_modules/blue-tape/bin/blue-tape.js test/**/*.ts src/**/*.spec.ts | tap-dot",
-    "test-cov": "ts-node node_modules/istanbul/lib/cli.js cover -e .ts --print none -x \"*.spec.ts\" blue-tape -- test/**/*.ts src/**/*.spec.ts | tap-dot",
+    "test-cov": "ts-node node_modules/istanbul/lib/cli.js cover --ext .ts --x  '**/*.d.ts' --print none -x \"*.spec.ts\" blue-tape -- test/**/*.ts src/**/*.spec.ts",
     "test": "npm run lint && npm run test-cov",
     "prepublish": "npm run build"
   },
@@ -79,11 +79,11 @@
   },
   "devDependencies": {
     "blue-tape": "^0.1.10",
-    "istanbul": "blakeembrey/istanbul#transpiler-support",
+    "istanbul": "gotwarlost/istanbul#v1",
     "nock": "^3.0.0",
     "pre-commit": "^1.0.6",
     "tap-dot": "^1.0.0",
-    "ts-node": "^0.5.0",
+    "ts-node": "0.5.2",
     "tslint": "^2.5.1"
   }
 }


### PR DESCRIPTION
* Use my istanbul v1 branch
* Pin to `ts-node@0.5.2`
* Remove the pipe to `tap-dot` - this is just for ease of debugging and does not materially affect any outcome

Please run this locally and verify that the coverage looks like you expect it to and the HTML reports make sense.

Also note this hack: https://github.com/istanbuljs/istanbul-lib-source-maps/blob/master/lib/map-store.js#L53-L55

For some reason the typescript compiler (or maybe your wrapper?) base64 encodes an object that is not a source map but looks like `{ sourcemap: { real sourcemap_object} }`

Let's sync up on the final form of this integration after you've had a chance to play with it.