### PR TITLE
Typings directory structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "build": "rm -rf dist/ && tsc",
-    "test-spec": "ts-node node_modules/blue-tape/bin/blue-tape.js test/**/*.ts src/**/*.spec.ts | tap-dot",
-    "test-cov": "ts-node node_modules/istanbul/lib/cli.js cover -e .ts --print none -x \"*.d.ts\" -x \"*.spec.ts\" blue-tape -- test/**/*.ts src/**/*.spec.ts | tap-dot",
+    "test-spec": "ts-node node_modules/blue-tape/bin/blue-tape.js \"src/**/*.spec.ts\" | tap-spec",
+    "test-cov": "ts-node node_modules/istanbul/lib/cli.js cover -e .ts --print none -x \"*.d.ts\" -x \"*.spec.ts\" blue-tape -- \"src/**/*.spec.ts\" | tap-spec",
     "test": "npm run lint && npm run test-cov",
     "prepublish": "npm run build"
   },
@@ -82,7 +82,7 @@
     "istanbul": "1.0.0-alpha.2",
     "nock": "^3.0.0",
     "pre-commit": "^1.0.6",
-    "tap-dot": "^1.0.0",
+    "tap-spec": "^4.1.1",
     "ts-node": "^0.5.0",
     "tslint": "^2.5.1"
   }

--- a/src/__test__/install-fixture/.gitignore
+++ b/src/__test__/install-fixture/.gitignore
@@ -1,0 +1,1 @@
+/typings/

--- a/src/__test__/install-fixture/custom_typings/test.d.ts
+++ b/src/__test__/install-fixture/custom_typings/test.d.ts
@@ -1,0 +1,3 @@
+function test (): boolean
+
+export default test

--- a/src/__test__/install-fixture/typings.json
+++ b/src/__test__/install-fixture/typings.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "test": "file:custom_typings/test.d.ts"
+  }
+}

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -1,8 +1,9 @@
 import test = require('tape')
 import { EOL } from 'os'
-import { join } from 'path'
+import { join, relative } from 'path'
 import { install } from './install'
 import { readFile } from './utils/fs'
+import { VERSION } from './typings'
 
 const pkg = require('../package.json')
 
@@ -12,7 +13,6 @@ test('install', t => {
 
     return install({
       cwd: FIXTURE_DIR,
-      meta: false,
       production: false
     })
       .then(function () {
@@ -28,7 +28,15 @@ test('install', t => {
         t.equal(browserDts, `/// <reference path="browser/definitions/test/test.d.ts" />${EOL}`)
 
         t.equal(mainFile, browserFile)
-        t.equal(mainFile, `declare module \'test\' {${EOL}  function test(): boolean${EOL}${EOL}  export default test${EOL}}`)
+        t.equal(mainFile, [
+          `// Compiled using typings@${VERSION}`,
+          `// Source: ${relative(FIXTURE_DIR, join(FIXTURE_DIR, 'custom_typings/test.d.ts'))}`,
+          `declare module \'test\' {`,
+          `  function test(): boolean`,
+          ``,
+          `  export default test`,
+          `}`
+        ].join(EOL))
       })
   })
 })

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -1,4 +1,5 @@
 import test = require('blue-tape')
+import Promise = require('native-or-bluebird')
 import { EOL } from 'os'
 import { join, relative } from 'path'
 import { install } from './install'

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -1,4 +1,4 @@
-import test = require('tape')
+import test = require('blue-tape')
 import { EOL } from 'os'
 import { join, relative } from 'path'
 import { install } from './install'

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -1,0 +1,34 @@
+import test = require('tape')
+import { EOL } from 'os'
+import { join } from 'path'
+import { install } from './install'
+import { readFile } from './utils/fs'
+
+const pkg = require('../package.json')
+
+test('install', t => {
+  t.test('install dependencies', t => {
+    const FIXTURE_DIR = join(__dirname, '__test__/install-fixture')
+
+    return install({
+      cwd: FIXTURE_DIR,
+      meta: false,
+      production: false
+    })
+      .then(function () {
+        return Promise.all([
+          readFile(join(FIXTURE_DIR, 'typings/main.d.ts'), 'utf8'),
+          readFile(join(FIXTURE_DIR, 'typings/browser.d.ts'), 'utf8'),
+          readFile(join(FIXTURE_DIR, 'typings/main/definitions/test/test.d.ts'), 'utf8'),
+          readFile(join(FIXTURE_DIR, 'typings/browser/definitions/test/test.d.ts'), 'utf8')
+        ])
+      })
+      .then(function ([mainDts, browserDts, mainFile, browserFile]) {
+        t.equal(mainDts, `/// <reference path="main/definitions/test/test.d.ts" />${EOL}`)
+        t.equal(browserDts, `/// <reference path="browser/definitions/test/test.d.ts" />${EOL}`)
+
+        t.equal(mainFile, browserFile)
+        t.equal(mainFile, `declare module \'test\' {${EOL}  function test(): boolean${EOL}${EOL}  export default test${EOL}}`)
+      })
+  })
+})

--- a/src/typings.spec.ts
+++ b/src/typings.spec.ts
@@ -1,4 +1,4 @@
-import test = require('tape')
+import test = require('blue-tape')
 import { VERSION } from './typings'
 
 const pkg = require('../package.json')

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -22,10 +22,10 @@ const requestFileCache = popsicleCache({
   store: new popsicleCache.Store({ path: join(CACHE_DIR, 'http') })
 })
 
-const mainTypingsDir = join(TYPINGS_DIR, 'definitions/main')
-const browserTypingsDir = join(TYPINGS_DIR, 'definitions/browser')
-const ambientMainTypingsDir = join(TYPINGS_DIR, 'ambient/main')
-const ambientBrowserTypingsDir = join(TYPINGS_DIR, 'ambient/browser')
+const mainTypingsDir = join(TYPINGS_DIR, 'main/definitions')
+const browserTypingsDir = join(TYPINGS_DIR, 'browser/definitions')
+const ambientMainTypingsDir = join(TYPINGS_DIR, 'main/ambient')
+const ambientBrowserTypingsDir = join(TYPINGS_DIR, 'browser/ambient')
 
 export type Stats = fs.Stats
 
@@ -253,8 +253,8 @@ function getDependencyLocation (options: DefinitionOptions) {
   const browserDtsFile = join(typingsDir, DTS_BROWSER_FILE)
   const mainDir = options.ambient ? ambientMainTypingsDir : mainTypingsDir
   const browserDir = options.ambient ? ambientBrowserTypingsDir : browserTypingsDir
-  const mainFile = join(options.cwd, mainDir, toDefinition(options.name))
-  const browserFile = join(options.cwd, browserDir, toDefinition(options.name))
+  const mainFile = join(options.cwd, mainDir, options.name, toDefinition(options.name))
+  const browserFile = join(options.cwd, browserDir, options.name, toDefinition(options.name))
 
   return { mainFile, browserFile, mainDtsFile, browserDtsFile }
 }


### PR DESCRIPTION
Closes #54

* Moved `typings/` structure around to match proposal in #54
* Add small test suite for install
* Changed from `tap-dot` formatter