### PR TITLE
Remove the entire dependency in `typings/`

### DIFF
--- a/custom_typings/rimraf.d.ts
+++ b/custom_typings/rimraf.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for rimraf
+// Project: https://github.com/isaacs/rimraf
+// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// Imported from: https://github.com/soywiz/typescript-node-definitions/rimraf.d.ts
+
+declare module "rimraf" {
+	function rimraf(path: string, callback: (error: Error) => void): void;
+	module rimraf {
+		export function sync(path: string): void;
+		export var EMFILE_MAX: number;
+		export var BUSYTRIES_MAX: number;
+	}
+	export = rimraf;
+}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "popsicle-cache": "^1.0.0",
     "popsicle-status": "^0.2.0",
     "promise-finally": "^2.0.1",
+    "rimraf": "^2.4.4",
     "semver": "^5.0.1",
     "sort-keys": "^1.0.0",
     "strip-bom": "^2.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
     "custom_typings/popsicle-status.d.ts",
     "custom_typings/popsicle.d.ts",
     "custom_typings/proxyquire.d.ts",
+    "custom_typings/rimraf.d.ts",
     "custom_typings/semver.d.ts",
     "custom_typings/sort-keys.d.ts",
     "custom_typings/strip-bom.d.ts",


### PR DESCRIPTION
Using `rimraf` to delete recursively, even though only a single file *should* exist in there.