### PR TITLE
Infer dependency name on installation

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -15,7 +15,7 @@ export interface InstallDependencyOptions {
   save?: boolean
   saveDev?: boolean
   ambient?: boolean
-  name?: string
+  name: string
   cwd: string
   source?: string
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,4 +1,4 @@
-export { install, installDependency } from './install'
+export { install, installDependency, InstallOptions, InstallDependencyOptions } from './install'
 export { uninstallDependency } from './uninstall'
 export { init } from './init'
 export { bundle } from './bundle'

--- a/src/utils/parse.spec.ts
+++ b/src/utils/parse.spec.ts
@@ -1,6 +1,6 @@
 import test = require('blue-tape')
 import { normalize } from 'path'
-import { parseDependency, resolveDependency } from './parse'
+import { parseDependency, resolveDependency, inferDependencyName } from './parse'
 import { CONFIG_FILE } from './config'
 
 test('parse', t => {
@@ -239,7 +239,7 @@ test('parse', t => {
       const actual = parseDependency('http://example.com/foo/' + CONFIG_FILE)
       const expected = {
         raw: 'http://example.com/foo/' + CONFIG_FILE,
-        type: 'hosted',
+        type: 'http',
         location: 'http://example.com/foo/' + CONFIG_FILE
       }
 
@@ -254,9 +254,19 @@ test('parse', t => {
   })
 
   t.test('resolve dependency', t => {
-    t.test('github', t => {
-      t.equal(resolveDependency('github:foo/bar/baz/x.d.ts', '../lib/test.d.ts'), 'github:foo/bar/lib/test.d.ts')
-      t.end()
-    })
+    t.equal(resolveDependency('github:foo/bar/baz/x.d.ts', '../lib/test.d.ts'), 'github:foo/bar/lib/test.d.ts')
+    t.equal(resolveDependency('http://example.com/foo/bar.d.ts', 'x.d.ts'), 'http://example.com/foo/x.d.ts')
+
+    t.end()
+  })
+
+  t.test('infer dependency name', t => {
+    t.equal(inferDependencyName('github:foo/bar'), 'bar')
+    t.equal(inferDependencyName('npm:@scoped/package'), '@scoped/package')
+    t.equal(inferDependencyName('bower:dependency/path/to/type.d.ts'), 'dependency')
+    t.equal(inferDependencyName('github:a/b/c/d.d.ts'), 'd')
+    t.equal(inferDependencyName('github:typings/typed-debug'), 'debug')
+
+    t.end()
   })
 })

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -34,11 +34,26 @@ export function normalizeSlashes (path: string) {
  * Infer the definition name from a location string.
  */
 export function inferDefinitionName (location: string) {
-  if (isHttp(location)) {
-    return basename(parseUrl(location).pathname, '.d.ts')
+  if (isDefinition(location)) {
+    let pathname = location
+
+    if (isHttp(location)) {
+      pathname = parseUrl(location).pathname
+    }
+
+    return sanitizeDefinitionName(basename(pathname, '.d.ts'))
+  }
+}
+
+/**
+ * Attempt to sanitize the definition name (stripping "typings", etc).
+ */
+export function sanitizeDefinitionName (name: string) {
+  if (name == null) {
+    return name
   }
 
-  return basename(location, '.d.ts')
+  return name.replace(/^(?:typings|typed)\-|\-(?:typings|typed)$/, '')
 }
 
 /**


### PR DESCRIPTION
Only when name is omitted (e.g. non-registry installation without `-n`).

Closes https://github.com/typings/typings/issues/39.