### PR TITLE
Resolve files when module name is overridden

### DIFF
--- a/src/lib/__test__/fixtures/compile-file-module-override/imported.d.ts
+++ b/src/lib/__test__/fixtures/compile-file-module-override/imported.d.ts
@@ -1,0 +1,1 @@
+export declare function isNotDep (): boolean;

--- a/src/lib/__test__/fixtures/compile-file-module-override/index.d.ts
+++ b/src/lib/__test__/fixtures/compile-file-module-override/index.d.ts
@@ -1,0 +1,1 @@
+export * from './imported'

--- a/src/lib/__test__/fixtures/compile-file-module-override/node_modules/dep/index.d.ts
+++ b/src/lib/__test__/fixtures/compile-file-module-override/node_modules/dep/index.d.ts
@@ -1,0 +1,1 @@
+export declare function isDep (): boolean;

--- a/src/lib/__test__/fixtures/compile-file-module-override/node_modules/dep/package.json
+++ b/src/lib/__test__/fixtures/compile-file-module-override/node_modules/dep/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.js"
+}

--- a/src/lib/__test__/fixtures/compile-file-module-override/package.json
+++ b/src/lib/__test__/fixtures/compile-file-module-override/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test",
+  "main": "index.js",
+  "browser": {
+    "./imported.js": "dep"
+  },
+  "dependencies": {
+    "dep": "0.0.0"
+  }
+}

--- a/src/lib/__test__/fixtures/compile-module-file-override/index.d.ts
+++ b/src/lib/__test__/fixtures/compile-module-file-override/index.d.ts
@@ -1,0 +1,3 @@
+import * as foo from 'dep'
+
+export = foo

--- a/src/lib/__test__/fixtures/compile-module-file-override/override.d.ts
+++ b/src/lib/__test__/fixtures/compile-module-file-override/override.d.ts
@@ -1,0 +1,3 @@
+declare function test (): string;
+
+export = test;

--- a/src/lib/__test__/fixtures/compile-module-file-override/package.json
+++ b/src/lib/__test__/fixtures/compile-module-file-override/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "main": "index.js",
+  "browser": {
+    "dep": "./override.js"
+  }
+}

--- a/src/lib/__test__/fixtures/node-resolve-error/package.json
+++ b/src/lib/__test__/fixtures/node-resolve-error/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "index.js"
+  "main": "index.js",
   "dependencies": {
     "test": "1.0.0"
   }


### PR DESCRIPTION
Fix un-handled browser override condition when it went from a module name to relative file.