### PR TITLE
Add project name guessing

### DIFF
--- a/src/__test__/init-guess-name/bower.json
+++ b/src/__test__/init-guess-name/bower.json
@@ -1,0 +1,4 @@
+{
+  "name": "typings-test",
+  "version": "0.1.0"
+}

--- a/src/__test__/init-guess-name/package.json
+++ b/src/__test__/init-guess-name/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "typings-test",
+  "version": "0.1.0"
+}

--- a/src/init.spec.ts
+++ b/src/init.spec.ts
@@ -45,4 +45,20 @@ test('init', t => {
         return thenify(unlink)(path)
       })
   })
+
+  t.test('guess project name', t => {
+    const FIXTURE_DIR = join(__dirname, '__test__/init-guess-name')
+    const path = join(FIXTURE_DIR, CONFIG_FILE)
+
+    return init({ cwd: FIXTURE_DIR})
+      .then(function () {
+        return readJson(path)
+      })
+      .then(function (config) {
+        t.equals(config.name, 'typings-test')
+      })
+      .then(function () {
+        return thenify(unlink)(path)
+      })     
+  })
 })

--- a/src/init.ts
+++ b/src/init.ts
@@ -43,6 +43,15 @@ interface TsdJson {
 }
 
 /**
+ * The files to check for existing names when naming a package
+ */
+
+const CONFIG_NAMES: string[] = [
+  'package.json',
+  'bower.json'
+]
+
+/**
  * Update an old `tsd.json` format to the new format.
  */
 function upgradeTsdJson (tsdJson: TsdJson): ConfigJson {
@@ -78,6 +87,23 @@ function upgrade (options: InitOptions) {
 }
 
 /**
+ * Make a smart guess of the project from either the `package.json` or `bower.json` files.
+ */
+
+function guessProjectName (options: InitOptions) : string {
+  for (let i = 0; i < CONFIG_NAMES.length; i++) {
+    try {
+      const pack = require(join(options.cwd, CONFIG_NAMES[i]))
+      if (pack.name != null) {
+        return pack.name
+      }
+    } catch (e) {}
+  }
+
+  return null
+}
+
+/**
  * Initialize a configuration file here.
  */
 export function init (options: InitOptions) {
@@ -92,6 +118,9 @@ export function init (options: InitOptions) {
       if (options.upgrade) {
         return upgrade(options)
       }
+
+      let config = DEFAULT_CONFIG
+      config.name = guessProjectName(options)
 
       return DEFAULT_CONFIG
     })


### PR DESCRIPTION
> This adds a new step to the "init" process. Based on the `package.json`
and `bower.json` files which exist within the CWD it will choose the
name for the project to put in the `typings.json` file.

Greetings! I am just starting out learning TypeScript and the rest of the tools in the ecosystem. I was using this project in one of my new projects, and thought that this was a feature that the community might benefit from.

I'd really appreciate the feedback if some of this code is unidiomatic, and totally understand if you do not want this feature in the code base (Not like it was asked for  :smiley_cat:).