### PR TITLE
Added a Typings, the Registry and Versions doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ In both cases the `--ambient` flag is required in order that Definitely Typed is
 
 * Package manager parity
   * Familiar commands like `init`, `install`, `rm` and `ls`
+  * Support for installation of type definitions based on the true version number of the package you are using.  (Rather than on a SHA hash as with TSD.)  [Read more.](/docs/typings-the-registy-and-versions.md)
 * Installation from GitHub, BitBucket, NPM dependencies, Bower dependencies and HTTP(s)
   * If a project uses Typings, you can install it locally - try `typings install npm:popsicle`
 * Simple typings configuration file

--- a/docs/how-typings-makes-external-modules-first-class.md
+++ b/docs/how-typings-makes-external-modules-first-class.md
@@ -4,7 +4,7 @@ Often the best way to understand something is through example.  Let's imagine yo
 
 In your code you're then free to use jQuery as you like, for instance:
 
-```
+```ts
 import * as littleOldJ from 'oldJ';
 ```
 
@@ -24,7 +24,7 @@ Still a little confused?  Stick with me; we'll step through an example which sho
 
 There's a very straightforward type definition for [`domready`](https://github.com/ded/domready) in the Typings Registry.  The code that makes up the definition is as simple as:
 
-```
+```ts
 declare function domready(callback: () => any) : void;
 
 export = domready;
@@ -32,7 +32,7 @@ export = domready;
 
 Couldn't be simpler.  To install that definition it's a case of `typings install domready` which will create a `typings/main/definitions/domready/domready.d.ts` file in your repo:
 
-```
+```ts
 // Compiled using typings@0.6.5
 // Source: https://raw.githubusercontent.com/unional/typed-domready/881449d638c89897b1e70172ab5413b8886b4ef9/main.d.ts
 declare module 'domready/main' {
@@ -61,7 +61,7 @@ domready
 
 Typings looked up domready in the Typings Registry at this location: https://github.com/typings/registry/blob/master/npm/domready.json.  That file contained this data:
 
-```
+```json
 {
   "versions": {
     "1.0.8": "github:unional/typed-domready#881449d638c89897b1e70172ab5413b8886b4ef9"
@@ -73,7 +73,7 @@ Plainly `github:unional/typed-domready#881449d638c89897b1e70172ab5413b8886b4ef9`
 
 And here's something you should notice; https://github.com/unional/typed-domready contains a key file: `typings.json`:
 
-```
+```json
 {
   "name": "domready",
   "main": "main.d.ts",

--- a/docs/typings-the-registry-and-versions.md
+++ b/docs/typings-the-registry-and-versions.md
@@ -6,7 +6,7 @@ In contrast, TSD was bound to Definitely Typed which officially only supports th
 
 Typings does not have these limitations as it uses a [dedicated registry](https://github.com/typings/registry), where each library is defined in JSON with the ability to have multiple versions.  Let's take a look at the Typing Registry's [Moment's](http://momentjs.com/) [`moment.json`](https://github.com/typings/registry/blob/master/npm/moment.json):
 
-```
+```json
 {
   "versions": {
     "2.10.5": "github:typed-typings/npm-moment#a4075cd50e63efbedd850f654594f293ab81a385"
@@ -18,7 +18,7 @@ As you can see, this file contains reference to a single version of Moment's typ
 
 Well if some kind soul writes a Moment type definition version `1.7.0`, then the registry could be updated to reference it. It'd end up looking a little like this:
 
-```
+```json
 {
   "versions": {
     "1.7.0": "github:some-kind-soul/moment-1-7-0-typing#iamahash1iamahash1iamahash1",
@@ -31,10 +31,10 @@ To install this type definition you'd enter: `typings install moment@1.7.0`.  Th
 
 Over time it's more likely that all the versions of a type definition will be driven off a single repo.  This repo will evolve in line with the package it provides type definitions for.  In this scenario a Typings Registry JSON file will point back to the same type definition but with different versions effectively aliasing SHA hashes.  So something like this might be plausible:
 
-```
+```json
 {
   "versions": {
-    "2.10.5": "github:typed-typings/npm-moment#a4075cd50e63efbedd850f654594f293ab81a385"
+    "2.10.5": "github:typed-typings/npm-moment#a4075cd50e63efbedd850f654594f293ab81a385",
     "3.0.0": "github:typed-typings/npm-moment#iamafuturehash1iamafuturehash1iamafuturehash1"
   }
 }

--- a/docs/typings-the-registry-and-versions.md
+++ b/docs/typings-the-registry-and-versions.md
@@ -1,0 +1,41 @@
+# Typings, the Registy and Versions
+
+Typings supports multiple versions of type definitions for **different versions** of a single library.  
+
+In contrast, TSD was bound to Definitely Typed which officially only supports the latest and greatest type definitions. Installation of older type definitions with TSD relied on the user knowing an unmemorable SHA hash. Also, there was no way for older type definitions to continue to be evolved side by side with existing typings.
+
+Typings does not have these limitations as it uses a [dedicated registry](https://github.com/typings/registry), where each library is defined in JSON with the ability to have multiple versions.  Let's take a look at the Typing Registry's [Moment's](http://momentjs.com/) [`moment.json`](https://github.com/typings/registry/blob/master/npm/moment.json):
+
+```
+{
+  "versions": {
+    "2.10.5": "github:typed-typings/npm-moment#a4075cd50e63efbedd850f654594f293ab81a385"
+  }
+}
+```
+
+As you can see, this file contains reference to a single version of Moment's type definition: [version 2.10.5](https://github.com/moment/moment/blob/develop/CHANGELOG.md#2105-see-full-changelog).  Let's imagine I'm working on a project which is using [Moment version 1.7.0](https://github.com/moment/moment/blob/develop/CHANGELOG.md#170-see-discussion).  The `2.10.5` definition is no good for me.  I need `1.7.0`.  What to do?
+
+Well if some kind soul writes a Moment type definition version `1.7.0`, then the registry could be updated to reference it. It'd end up looking a little like this:
+
+```
+{
+  "versions": {
+    "1.7.0": "github:some-kind-soul/moment-1-7-0-typing#iamahash1iamahash1iamahash1",
+    "2.10.5": "github:typed-typings/npm-moment#a4075cd50e63efbedd850f654594f293ab81a385"
+  }
+}
+```
+
+To install this type definition you'd enter: `typings install moment@1.7.0`.  This would bring down the `1.7.0` definition instead of the `2.10.5` one.  (Incidentally executing the same commmand but without the `@version.number` would bring down the latest and greatest version of the `moment` type definitions, as you might expect.)
+
+Over time it's more likely that all the versions of a type definition will be driven off a single repo.  This repo will evolve in line with the package it provides type definitions for.  In this scenario a Typings Registry JSON file will point back to the same type definition but with different versions effectively aliasing SHA hashes.  So something like this might be plausible:
+
+```
+{
+  "versions": {
+    "2.10.5": "github:typed-typings/npm-moment#a4075cd50e63efbedd850f654594f293ab81a385"
+    "3.0.0": "github:typed-typings/npm-moment#iamafuturehash1iamafuturehash1iamafuturehash1"
+  }
+}
+```


### PR DESCRIPTION
This is to resolve https://github.com/typings/typings/issues/191

I think this is pretty good for now.  I did wonder if it would be worth adding in a section at the end to outline the use case where someone wants to carry on evolving the type definition for an older version of a package (eg Angular 1.2.x users who can't upgrade due to IE support) and how the Typings Registry allows for that.

If you think that'd be handy I can submit a subsequent PR when I get some time to cater for that.

Is this all OK otherwise?  I tweaked it a little from the original issue but not a great deal.