### PR TITLE
Improve command line messaging around stripped references

### DIFF
--- a/src/bin/typings-install.ts
+++ b/src/bin/typings-install.ts
@@ -67,23 +67,23 @@ interface PrintOutput {
 /**
  * Print the result to the user.
  */
-function printResult (output: PrintOutput, options?: { name: string, save: boolean, saveDev: boolean, ambient: boolean }) {
+function printResult (output: PrintOutput, options?: { name: string, save?: boolean, saveDev?: boolean, ambient?: boolean }) {
   if (output.references) {
     const references = Object.keys(output.references)
 
     if (references.length) {
-      const strippedReferences = references.map(reference => {
-        const info = output.references[reference]
-        return { reference, referenceName: listify(info.map(x => x.name)) }
-      });
-      
-      console.log(chalk.bold('References (stripped):'))
-      strippedReferences.forEach(r => console.log(`  ${r.reference} ${chalk.gray(`(from ${r.referenceName})`)}`))
+      console.log(chalk.bold(`References (stripped):`))
+      const strippedReferenceNames = references.map(reference => listify(output.references[reference].map(x => x.name)));
+      strippedReferenceNames.forEach(rn => console.log(`  ${chalk.gray(`(from ${rn})`)}`))
       console.log('')
       
       if (options.ambient) {
-        console.log(chalk.bold('As you\'re installing ambient references you may want to install the stripped references as well.  You can do that by executing the following commands:'))
-        const flags = Object.keys(options).filter(f => f !== 'name').map(f => ` --${f}`)
+        console.log(chalk.bold('As you\'re installing ambient references you may want to install the stripped references as well. You can do that by executing the following commands:'))
+        const flags = [].concat(
+            options.save ? ['save'] : [],
+            options.saveDev ? ['saveDev'] : [],
+            'ambient'
+        )
         strippedReferences.forEach(r => console.log(`  typings install '${r.reference}'${ flags }`))
         console.log('')
       }
@@ -126,7 +126,7 @@ function installer (args: Args & minimist.ParsedArgs) {
     function handle (options: InstallDependencyOptions) {
       return loader(installDependency(location, options), args)
         .then(output => {
-          printResult(output, { name: options.name, save: options.save, saveDev: options.saveDev, ambient: options.ambient })
+          printResult(output, options)
         })
     }
 

--- a/src/bin/typings-install.ts
+++ b/src/bin/typings-install.ts
@@ -84,7 +84,7 @@ function printResult (output: PrintOutput, options?: { name: string, save?: bool
             options.saveDev ? ['saveDev'] : [],
             'ambient'
         )
-        strippedReferences.forEach(r => console.log(`  typings install '${r.reference}'${ flags }`))
+        references.forEach(r => console.log(`  typings install '${r}'${ flags }`))
         console.log('')
       }
     }

--- a/src/bin/typings-install.ts
+++ b/src/bin/typings-install.ts
@@ -80,10 +80,10 @@ function printResult (output: PrintOutput, options?: { name: string, save?: bool
       if (options.ambient) {
         console.log(chalk.bold('As you\'re installing ambient references you may want to install the stripped references as well. You can do that by executing the following commands:'))
         const flags = [].concat(
-            options.save ? ['save'] : [],
-            options.saveDev ? ['saveDev'] : [],
-            'ambient'
-        )
+            options.save ? ['--save'] : [],
+            options.saveDev ? ['--save-dev'] : [],
+            '--ambient'
+        ).join(' ')
         references.forEach(r => console.log(`  typings install '${r}'${ flags }`))
         console.log('')
       }


### PR DESCRIPTION
This PR is to address https://github.com/typings/typings/issues/227.  It seeks to add an extra comment for ambient typings upon installation where there are stripped references.  The comment is along the lines of that suggested by @blakeembrey. I've tweaked the wording so it should look like this:

```
As you're installing ambient references you may want to install the stripped references as well.  You can do that by executing the following commands:

typings install 'github:DefinitelyTyped/DefinitelyTyped/jquery/jquery.d.ts#1c4a34873c9e70cce86edd0e61c559e43dfa5f75' --save --ambient
```

I didn't see any tests related to command line prompts - please do alert me if there are some and I've missed them.

I've also discovered that Typings is not cross platform when it comes to development.  It has dependencies upon *nix commands like `rm rf` and `touch`.  As such I've been unable to test this on my own (windows) machine.  So please examine carefully.  I think I can amend the Typings development workflow to be cross platform; it doesn't look like there's anything major to do.  I'll try and address that in a subsequent PR when I get a moment.  I'll raise an issue to track this separately.