### PR TITLE
Made build and bootstrap cross platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test-spec": "ts-node node_modules/blue-tape/bin/blue-tape.js \"src/**/*.spec.ts\" | tap-spec",
     "test-cov": "ts-node node_modules/istanbul/lib/cli.js cover -e .ts --print none -x \"*.d.ts\" -x \"*.spec.ts\" blue-tape -- \"src/**/*.spec.ts\" | tap-spec",
     "test": "npm run lint && npm run build && npm run dependency-check && npm run test-cov",
-    "bootstrap": "mkdir typings && touch typings/main.d.ts && node scripts-bootstrap.js && node dist/bin/typings.js install",
+    "bootstrap": "npm install shelljs && node scripts-bootstrap.js && node dist/bin/typings.js install",
     "prepublish": "node scripts-prepublish.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "LICENSE"
   ],
   "scripts": {
-    "lint": "# tslint \"src/**/*.ts\"",
-    "build": "rm -rf dist/ && tsc",
+    "lint": "echo \"deactivated for now: tslint \\\"src/**/*.ts\\\"",
+    "build": "rimraf dist && tsc",
     "dependency-check": "dependency-check . --entry dist/bin/typings-bundle.js --entry dist/bin/typings-init.js --entry dist/bin/typings-install.js --entry dist/bin/typings-list.js --entry dist/bin/typings-search.js --entry dist/bin/typings-uninstall.js --unused --no-dev -i bluebird",
     "test-spec": "ts-node node_modules/blue-tape/bin/blue-tape.js \"src/**/*.spec.ts\" | tap-spec",
     "test-cov": "ts-node node_modules/istanbul/lib/cli.js cover -e .ts --print none -x \"*.d.ts\" -x \"*.spec.ts\" blue-tape -- \"src/**/*.spec.ts\" | tap-spec",
     "test": "npm run lint && npm run build && npm run dependency-check && npm run test-cov",
-    "bootstrap": "mkdir -p typings && touch typings/main.d.ts && SKIP_PREPUBLISH=true npm install && npm run build 2> /dev/null; cat dist/init.js > /dev/null && node dist/bin/typings.js install",
-    "prepublish": "if [ ! $SKIP_PREPUBLISH ]; then npm run build; fi"
+    "bootstrap": "mkdir typings && touch typings/main.d.ts && node scripts-bootstrap.js && node dist/bin/typings.js install",
+    "prepublish": "node scripts-prepublish.js"
   },
   "repository": {
     "type": "git",
@@ -93,6 +93,8 @@
     "istanbul": "1.0.0-alpha.2",
     "nock": "^7.2.2",
     "pre-commit": "^1.0.6",
+    "rimraf": "^2.5.2",
+    "shelljs": "^0.6.0",
     "tap-spec": "^4.1.1",
     "ts-node": "^0.5.4",
     "tslint": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "lint": "echo \"deactivated for now: tslint \\\"src/**/*.ts\\\"",
+    "lint": "echo deactivated for now: tslint src/**/*.ts",
     "build": "rimraf dist && tsc",
     "dependency-check": "dependency-check . --entry dist/bin/typings-bundle.js --entry dist/bin/typings-init.js --entry dist/bin/typings-install.js --entry dist/bin/typings-list.js --entry dist/bin/typings-search.js --entry dist/bin/typings-uninstall.js --unused --no-dev -i bluebird",
     "test-spec": "ts-node node_modules/blue-tape/bin/blue-tape.js \"src/**/*.spec.ts\" | tap-spec",

--- a/scripts-bootstrap.js
+++ b/scripts-bootstrap.js
@@ -1,4 +1,8 @@
-require('shelljs/global');
+require('shelljs/global')
+
+mkdir('-p', 'typings')
+
+touch('typings/main.d.ts')
 
 echo('SKIP_PREPUBLISH=true')
 env['SKIP_PREPUBLISH'] = true
@@ -8,13 +12,13 @@ exec('rimraf dist')
 
 if (!which('tsc')) {
   echo('Sorry, this script requires tsc');
-  exit(1);
+  exit(1)
 }
 
 if (exec('tsc', {silent:true}).code !== 0) {
-  echo('tsc completed intial build as expected');
+  echo('tsc completed intial build as expected')
 }
 else {
-  echo('tsc completed without errors... that is unexpected and may merit investigation...');
-  exit(1);
+  echo('tsc completed without errors... that is unexpected and may merit investigation...')
+  exit(1)
 }

--- a/scripts-bootstrap.js
+++ b/scripts-bootstrap.js
@@ -1,0 +1,20 @@
+require('shelljs/global');
+
+echo('SKIP_PREPUBLISH=true')
+env['SKIP_PREPUBLISH'] = true
+
+exec('npm install')
+exec('rimraf dist')
+
+if (!which('tsc')) {
+  echo('Sorry, this script requires tsc');
+  exit(1);
+}
+
+if (exec('tsc', {silent:true}).code !== 0) {
+  echo('tsc completed intial build as expected');
+}
+else {
+  echo('tsc completed without errors... that is unexpected and may merit investigation...');
+  exit(1);
+}

--- a/scripts-prepublish.js
+++ b/scripts-prepublish.js
@@ -1,0 +1,8 @@
+require('shelljs/global');
+
+if (!env['SKIP_PREPUBLISH']) {
+  exec('npm run build')
+}
+else {
+  echo('Skipping prepublish step...');
+}


### PR DESCRIPTION
This mostly resolves https://github.com/typings/typings/issues/250.  It's achieved by making use of `rimraf` and `shelljs`. (I did contemplate just using `execSync` instead of `shelljs` but realised we're supporting node 0.10 and I don't think it shipped until 0.12)

The one outstanding task is making the `test-cov` script cross platform.  I'm afraid I'm not too clear on what is happening in this command:

```
ts-node node_modules/istanbul/lib/cli.js cover -e .ts --print none -x \"*.d.ts\" -x \"*.spec.ts\" blue-tape -- \"src/**/*.spec.ts\" | tap-spec
```

Perhaps you could provide some insight?  I think it may be the pipe at the end that upsets it.  

It's probably worth merging this PR as is (assuming it's all still passing for `*nix`) as it does solve the `npm run bootstrap` / `npm install` scenarios for Windows.  

Once I'm clearer about what's happening in `test-cov` I can implement a fix for that and submit another PR.