### PR TITLE
Update examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,7 +16,7 @@ For 1 and 2, you will create an ambient (global) typing.
 
 For 3, you will create an external module typing using `export =`.
 
-For 4, you will create an external module typing using ESM syntax (ES6/ES2015 default export and named export).
+For 4, you will create an external module typing using ES6 module syntax (default export and named export).
 
 For 5, you probably don't need to write typings for it.
 The declaration files included in the package should be accurate.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,13 +4,13 @@ Here are some examples you can use as a model when writing your typings.
 
 There are a few kinds of source package:
 
-1. Package that is part of the environment.
-2. Package that should be loaded in a script tag.
+1. Package that is part of the environment
+2. Package that should be loaded in a script tag
 3. Package that written in CommonJs / NodeJs style
   1. Package that also pollutes the global namespace
 4. Package that written in ES6+
   1. Package that also pollutes the global namespace
-5. Package that written in TypeScript and compiled to JavaScript with declaration `.d.ts` files.
+5. Package that written in TypeScript and compiled to JavaScript with declaration `.d.ts` files
 
 For 1 and 2, you will create an ambient (global) typing.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,9 +1,41 @@
 # Examples
 
-Here are some examples you can use as a model when writing your own type definitions.
+Here are some examples you can use as a model when writing your typings.
 
-## Single function
+There are a few kinds of source package:
 
+1. Package that is part of the environment.
+2. Package that should be loaded in a script tag.
+3. Package that written in CommonJs / NodeJs style
+  1. Package that also pollutes the global namespace
+4. Package that written in ES6+
+  1. Package that also pollutes the global namespace
+5. Package that written in TypeScript and compiled to JavaScript with declaration `.d.ts` files.
+
+For 1 and 2, you will create an ambient (global) typing.
+
+For 3, you will create an external module typing using `export =`.
+
+For 4, you will create an external module typing using ESM syntax (ES6/ES2015 default export and named export).
+
+For 5, you probably don't need to write typings for it.
+The declaration files included in the package should be accurate.
+
+
+## Ambient (global) typing
+### Namespace
+```ts
+// ABC.d.ts
+declare namespace ABC {
+  export function foo(): void;
+}
+
+// Consumer.ts
+ABC.foo();
+```
+
+## External Module with `export =`
+### Single function
 Exposing a single function.
 
 ```ts
@@ -24,12 +56,11 @@ export = xtend;
 
 * https://github.com/typed-typings/npm-xtend
 
-## Utility library
-
+### Utility library
 Exposing a collection of utility functions and classes.
 
 ```ts
-declare module JsDiff {
+declare namespace JsDiff {
   class Diff {}
   function diffChars(): any;
 }
@@ -39,8 +70,7 @@ export = JsDiff;
 
 * https://github.com/typed-typings/npm-diff
 
-## Function + utility
-
+### Function + utility
 Exposing a function, with utility methods.
 
 ```ts
@@ -55,14 +85,13 @@ export = tape;
 
 * https://github.com/typed-typings/npm-tape
 
-## Exporting class + static methods + utility (ES6)
-
+### Exporting class + static methods + utility
 ```ts
 declare class Promise <R> {
   static resolve(): Promise<void>;
 }
 
-declare module Promise {
+declare namespace Promise {
   export interface SpreadOption {}
   export function setScheduler (): any;
 }
@@ -72,8 +101,8 @@ export = Promise;
 
 * https://github.com/typed-typings/npm-bluebird
 
-## Named export (ES6)
-
+## External Module with ESM syntax
+### Named export
 Export directly using ES6 semantics without a module or namespace.
 
 ```ts


### PR DESCRIPTION
Added more info on different types of source package.
Use `declare namespace ...` instead of `declare module ...` in some examples.