### PR TITLE
Link to TypeScript handbook is broken.

### DIFF
--- a/docs/tsd.md
+++ b/docs/tsd.md
@@ -26,7 +26,7 @@ becomes:
 typings search react --ambient
 ```
 
-In both cases the `--ambient` flag is required; it includes DefinitelyTyped in the lookup. DT can generally be viewed as a source of ambient definitions (both internal and external). For clarity about what ambient definitions are, it's worth taking a look at the [TypeScript Handbook](http://www.typescriptlang.org/Handbook#modules-working-with-other-javascript-libraries).
+In both cases the `--ambient` flag is required; it includes DefinitelyTyped in the lookup. DT can generally be viewed as a source of ambient definitions (both internal and external). For clarity about what ambient definitions are, it's worth taking a look at the [TypeScript Handbook (Ambient Modules)](http://www.typescriptlang.org/docs/handbook/modules.html).
 
 # Upgrade
 


### PR DESCRIPTION
Updated link to TypeScript handbook to be as close as possible to existing one. New handbook doesn't have anchors for topics. 