### PR TITLE
Add reminder on `files -> typings.json`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -97,9 +97,12 @@ Ambient dependencies are type definitions that are global or otherwise provide i
 
 ## Should I Use The `typings` Field In `package.json`?
 
-If you're a module author, absolutely. However, it can't be used properly if any of your exposed API surface (the `.d.ts` files) have dependencies that come from Typings.
+If you're a module author, absolutely!
 
-Also, if you are using the `files` field to control which files will be available, remember to include `typings.json`.
+However, it can't be used properly if any of your exposed API surface (the `.d.ts` files) have dependencies that come from Typings.
+In that case, you can rely on `typings.json` to include typings for your dependencies so that your user can use `typings install npm:<your package>` to install your typings.
+
+Also, if you are using the `files` field in `package.json` to control which files will be available, remember to include `typings.json`.
 
 ## Where Do The Type Definitions Install?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -99,7 +99,7 @@ Ambient dependencies are type definitions that are global or otherwise provide i
 
 If you're a module author, absolutely!
 
-However, it can't be used properly if any of your exposed API surface (the `.d.ts` files) have dependencies that come from Typings.
+However, it can't be used properly if any of your exposed API surface (the `.d.ts` files) have dependencies that come from `typings`.
 In that case, you can rely on `typings.json` to include typings for your dependencies so that your user can use `typings install npm:<your package>` to install your typings.
 
 Also, if you are using the `files` field in `package.json` to control which files will be available, remember to include `typings.json`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -99,6 +99,8 @@ Ambient dependencies are type definitions that are global or otherwise provide i
 
 If you're a module author, absolutely. However, it can't be used properly if any of your exposed API surface (the `.d.ts` files) have dependencies that come from Typings.
 
+Also, if you are using the `files` field to control which files will be available, remember to include `typings.json`.
+
 ## Where Do The Type Definitions Install?
 
 Typings are compiled and written into the `typings/` directory alongside `typings.json`. The structure looks like this:


### PR DESCRIPTION
As mentioned in gitter:

Um….. suddenly I don’t get the purpose of `typings i npm:<pkg>`. If the typings is distributed in the source package, isn’t it safe to assume `package.json/typings` points to the file already thus `tsc` would pick it up automatically?

But if it still make sense, then this PR might worth merging. :smile: