### PR TITLE
Replace ! parser expansion symbol with ~

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,7 +16,7 @@ typings install [<name>=]<location>
   <location>  The location to read from (described below)
 
 Valid Locations:
-  [<source>!]<pkg>[@<version>][#<tag>]
+  [<source>~]<pkg>[@<version>][#<tag>]
   file:<path>
   github:<org>/<repo>[/<path>][#<commitish>]
   bitbucket:<org>/<repo>[/<path>][#<commitish>]

--- a/src/bin-install.ts
+++ b/src/bin-install.ts
@@ -14,7 +14,7 @@ typings install [<name>=]<location>
   <location>  The location to read from (described below)
 
 Valid Locations:
-  [<source>!]<pkg>[@<version>][#<tag>]
+  [<source>~]<pkg>[@<version>][#<tag>]
   file:<path>
   github:<org>/<repo>[/<path>][#<commitish>]
   bitbucket:<org>/<repo>[/<path>][#<commitish>]

--- a/src/bin-view.ts
+++ b/src/bin-view.ts
@@ -7,7 +7,7 @@ export function help () {
   return `
 typings view <pkg>
 
-  <pkg>  A registry expression like \`[<source>!]<pkg>\`
+  <pkg>  A registry expression like \`[<source>~]<pkg>\`
 
 Options:
   [--versions]  List all package versions


### PR DESCRIPTION
I was upgrading and the following stopped working:
```
typings install mocha --save --ambient
```
I used `typings i -h` to get some help when installing `mocha` and I saw:
```
typings install (with no arguments, in package directory)
typings install [<name>=]<location>

  <name>      Module name of the installed definition
  <location>  The location to read from (described below)

Valid Locations:
  [<source>!]<pkg>[@<version>][#<tag>]
  file:<path>
  github:<org>/<repo>[/<path>][#<commitish>]
  bitbucket:<org>/<repo>[/<path>][#<commitish>]
  npm:<pkg>[/<path>]
  bower:<pkg>[/<path>]
  http(s)://<host>/<path>

Options:
  [--save|-S]       Persist to "dependencies"
  [--save-dev|-D]   Persist to "devDependencies"
  [--save-peer|-P]  Persist to "peerDependencies"
  [--global|-G]     Install and persist as an global definition
    [-SG]           Persist to "globalDependencies"
    [-DG]           Persist to "globalDevDependencies"
  [--production]    Install only production dependencies (omits dev dependencies)

```
So I tried with:
```
typings install dt!mocha --global --save
```

It didn't work so I visited the GitHub docs and I found the following:

```
typings install dt~mocha --global --save
```

The release notes mention the following:

> Replace ! parser expansion symbol with ~ (! is a reserved bash symbol)

So I assume that the docs are outdated? 

If so, this PR should fix it.