### PR TITLE
Replaced source! with source~

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,7 +16,7 @@ typings install [<name>=]<location>
   <location>  The location to read from (described below)
 
 Valid Locations:
-  [<source>!]<pkg>[@<version>][#<tag>]
+  [<source>~]<pkg>[@<version>][#<tag>]
   file:<path>
   github:<org>/<repo>[/<path>][#<commitish>]
   bitbucket:<org>/<repo>[/<path>][#<commitish>]


### PR DESCRIPTION
In the docs/commands file, the install ready `<source>!`... when the correct syntax is `<source>~`.  I spent bloody ages trying to work out why the docs didn't work.

It seems that the `typings install --help` command returns the correct syntax in this branch, although it's not yet released - I guess this will come through shortly