### PR TITLE
`typings command --help` should include description of command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -46,7 +46,7 @@ Aliases: i, in
 
 ## Uninstall
 
-Remove a dependency from the typings/ directory, and optionally remove from `typings.json`.
+Remove a dependency from the `typings/` directory, and optionally remove from `typings.json`.
 
 ```
 typings uninstall <name> [--save|--save-dev|--save-peer] [--global]
@@ -75,7 +75,7 @@ Options:
 
 ## List
 
-Print the typings dependency tree.
+Print the typings dependency tree for the current project.
 
 ```
 typings list
@@ -117,7 +117,7 @@ Options:
 
 ## Open
 
-Get the full URL from a Typings location
+Get the full URL from a Typings location.
 
 ```
 typings open <location>
@@ -127,7 +127,7 @@ typings open <location>
 
 ## View
 
-Get information for a package on the Typings Registry
+Get information for a package on the Typings Registry.
 
 ```
 typings view <pkg>
@@ -142,7 +142,7 @@ Aliases: info
 
 ## Prune
 
-Prune extraneous typings from directory
+Prune extraneous typings from current project.
 
 ```
 typings prune

--- a/src/bin-bundle.ts
+++ b/src/bin-bundle.ts
@@ -5,6 +5,8 @@ export function help () {
   return `
 typings bundle --out <filepath>
 
+Bundle the current project types into an single global module.
+
 Options:
   [--out|-o] <filepath>  The bundled output file path
   [--global|-G]          Bundle as an global definition

--- a/src/bin-init.ts
+++ b/src/bin-init.ts
@@ -5,6 +5,8 @@ export function help () {
   return `
 typings init
 
+Initialize a new typings.json file. If you're currently using TSD, you can use \`--upgrade\` to convert \`tsd.json\` to \`typings.json\`.
+
 Options:
   [--upgrade]    Upgrade \`tsd.json\` to \`typings.json\`
 `

--- a/src/bin-install.ts
+++ b/src/bin-install.ts
@@ -8,6 +8,8 @@ export function help () {
 typings install (with no arguments, in package directory)
 typings install [<name>=]<location>
 
+Write a dependency to the \`typings/\` directory, optionally persisting it in \`typings.json\`.
+
   <name>      Module name of the installed definition
   <location>  The location to read from (described below)
 

--- a/src/bin-list.ts
+++ b/src/bin-list.ts
@@ -6,6 +6,8 @@ export function help () {
   return `
 typings list
 
+Print the typings dependency tree for the current project.
+
 Options:
   [--production] List only production dependencies (omit dev dependencies)
 

--- a/src/bin-open.ts
+++ b/src/bin-open.ts
@@ -5,6 +5,8 @@ export function help () {
   return `
 typings open <location>
 
+Get the full URL from a Typings location.
+
   <location>  A known Typings location with scheme (see typings install -h)
 `
 }

--- a/src/bin-prune.ts
+++ b/src/bin-prune.ts
@@ -5,6 +5,8 @@ export function help () {
   return `
 typings prune
 
+Prune extraneous typings from current project.
+
 Options:
   [--production] Also prune non-production dependencies
 `

--- a/src/bin-search.ts
+++ b/src/bin-search.ts
@@ -6,6 +6,8 @@ export function help () {
   return `
 typings search [query]
 
+Search the Typings Registry for type defintions.
+
 Options:
   [--name] <name>     Search for definitions by exact name (E.g. only "react")
   [--source] <source> The registry mirror (E.g. "npm", "bower", "env", "global", "dt", ...)

--- a/src/bin-uninstall.ts
+++ b/src/bin-uninstall.ts
@@ -6,6 +6,8 @@ export function help () {
   return `
 typings uninstall <name> [--save|--save-dev|--save-peer] [--global]
 
+Remove a dependency from the \`typings/\` directory, and optionally remove from \`typings.json\`.
+
 Options:
   [--save|-S]       Remove from "dependencies"
   [--save-dev|-D]   Remove from "devDependencies"

--- a/src/bin-view.ts
+++ b/src/bin-view.ts
@@ -7,6 +7,8 @@ export function help () {
   return `
 typings view <pkg>
 
+Get information for a package on the Typings Registry.
+
   <pkg>  A registry expression like \`[<source>~]<pkg>\`
 
 Options:


### PR DESCRIPTION
Say I type `typings list --help`. I get:

```
typings list

Options:
  [--production] List only production dependencies (omit dev dependencies)

Aliases: la, ll, ls
```

After reading this, I still don't know what `typings list` does. My expected behavior is that the `--help` for a command will explain the command, not just its options.

To address this, the attached patch copies the one-line description from `commands.md` into the individual command `help()` functions. I have also addressed minor style inconsistencies in the descriptions themselves (periods, backticks, inconsistent way the project in the current directory is referred to).

I have built this PR as described in the README but have not tested it. I can not figure out how to invoke the locally built `typings` after building. (Perhaps this information should be in the README).