### PR TITLE
Updated faq.md to make .typingsrc usage more explicit

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,7 +5,7 @@
 - [My global dependencie(s) are not installed](#references)
 - [How do I use Typings with version control?](#how-do-i-use-typings-with-version-control)
 - [How do I write typings definitions?](#writing-typings-definitions)
-- [How to configure typings?](#configuration)
+- [How do I configure typings with `.typingsrc`?](#configuration)
 - [What are global dependencies?](#what-are-global-dependencies)
 - [Should I use the `typings` field in `package.json`?](#should-i-use-the-typings-field-in-packagejson)
 - [Where do the type definitions install?](#where-do-the-type-definitions-install)


### PR DESCRIPTION
I just started a new gig which landed me using Typings behind a corporate firewall and needing to deactivate the SSL.  When it came to looking up `.typingsrc` information I initially missed it as I trawled around the typings repo; I thought this minor title change might aid discoverability.  

What do you think?