### PR TITLE
Change the name description of install

### DIFF
--- a/src/bin-install.ts
+++ b/src/bin-install.ts
@@ -8,7 +8,7 @@ export function help () {
 typings install (with no arguments, in package directory)
 typings install [<name>=]<location>
 
-  <name>      Module name of the installed definition
+  <name>      Module name alias
   <location>  The location to read from (described below)
 
 Valid Locations:

--- a/src/bin-install.ts
+++ b/src/bin-install.ts
@@ -8,7 +8,7 @@ export function help () {
 typings install (with no arguments, in package directory)
 typings install [<name>=]<location>
 
-  <name>      Module name alias
+  <name>      Alternate name of the definition
   <location>  The location to read from (described below)
 
 Valid Locations:


### PR DESCRIPTION
The original does not describe what it is for.

I think alias make more sense. 🌷 