### PR TITLE
Fix grammar in documentation for `--global` flag

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,7 +36,7 @@ Options:
   [--save|-S]       Persist to "dependencies"
   [--save-dev|-D]   Persist to "devDependencies"
   [--save-peer|-P]  Persist to "peerDependencies"
-  [--global|-G]     Install and persist as an global definition
+  [--global|-G]     Install and persist as a global definition
     [-SG]           Persist to "globalDependencies"
     [-DG]           Persist to "globalDevDependencies"
   [--production]    Install only production dependencies (omits dev dependencies)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,7 @@
 
 There are a number of kinds of source package which you may write typings for:
 
-1. Packages that, when loaded, extend the global scope environment with a number of new functions / variables / classes etc. An example is [mocha](https://github.com/mochajs/mocha) which has [an global type definition](https://github.com/typed-typings/env-mocha) and is listed in the [Typings Registry under env](https://github.com/typings/registry/blob/master/env/mocha.json).
+1. Packages that, when loaded, extend the global scope environment with a number of new functions / variables / classes etc. An example is [mocha](https://github.com/mochajs/mocha) which has [a global type definition](https://github.com/typed-typings/env-mocha) and is listed in the [Typings Registry under env](https://github.com/typings/registry/blob/master/env/mocha.json).
 
 2. Packages that should be loaded using a script tag. An example is [knockout](https://github.com/knockout/knockout) which has [this global type definition](https://github.com/typed-contrib/knockout/tree/master/global) and is listed in the [Typings Registry under global](https://github.com/typings/registry/blob/master/global/knockout.json).
 
@@ -12,7 +12,7 @@ There are a number of kinds of source package which you may write typings for:
 
 5. Packages that are written in TypeScript and compiled to JavaScript with declaration `.d.ts` files (eg [globalize-so-what-cha-want](https://www.npmjs.com/package/globalize-so-what-cha-want))
 
-For 1 and 2, you would create an global type definition.
+For 1 and 2, you would create a global type definition.
 
 For 3, you would create an external module type definition using `export =`.
 

--- a/docs/external-modules.md
+++ b/docs/external-modules.md
@@ -46,7 +46,7 @@ export = main;
 }
 ```
 
-If you look closely at the code above, you'll see the original type definition has been imported and "wrapped" as an global external module called `'domready'` by Typings.
+If you look closely at the code above, you'll see the original type definition has been imported and "wrapped" as a global external module called `'domready'` by Typings.
 
 How did this come about?  Well, this was the installation experience:
 

--- a/src/bin-install.ts
+++ b/src/bin-install.ts
@@ -32,7 +32,7 @@ Options:
   [--save|-S]       Persist to "dependencies"
   [--save-dev|-D]   Persist to "devDependencies"
   [--save-peer|-P]  Persist to "peerDependencies"
-  [--global|-G]     Install and persist as an global definition
+  [--global|-G]     Install and persist as a global definition
     [-SG]           Persist to "globalDependencies"
     [-DG]           Persist to "globalDevDependencies"
   [--production]    Install only production dependencies (omits dev dependencies)


### PR DESCRIPTION
In the documentation, "an global" should read "a global".