### PR TITLE
Add ability to set log level

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -8,7 +8,7 @@ import chalk = require('chalk')
 import updateNotifier = require('update-notifier')
 import extend = require('xtend')
 import { EventEmitter } from 'events'
-import { handle, logWarning, logInfo } from './support/cli'
+import { handle, logWarning, logInfo, setLogLevel } from './support/cli'
 import { Emitter } from 'typings-core'
 import { aliases } from './aliases'
 
@@ -30,6 +30,7 @@ interface Argv {
   limit?: number
   sort?: string
   unicode?: boolean
+  loglevel?: string
 }
 
 interface Args extends Argv {
@@ -41,7 +42,7 @@ const unicodeConfig = process.env.TYPINGS_CONFIG_UNICODE || process.env.NPM_CONF
 
 const argv = minimist<Argv>(process.argv.slice(2), {
   boolean: ['version', 'save', 'saveDev', 'savePeer', 'global', 'verbose', 'production', 'unicode'],
-  string: ['cwd', 'out', 'name', 'source', 'offset', 'limit', 'sort'],
+  string: ['cwd', 'out', 'name', 'source', 'offset', 'limit', 'sort', 'logLevel'],
   alias: {
     global: ['G'],
     version: ['v'],
@@ -64,6 +65,7 @@ function isTrue (value: string) {
 
 const cwd = argv.cwd ? resolve(argv.cwd) : process.cwd()
 const emitter: Emitter = new EventEmitter()
+const logLevel: number = argv.loglevel ? setLogLevel(argv.loglevel) : 0
 const args: Args = extend(argv, { emitter, cwd })
 
 // Notify the user of updates.
@@ -139,10 +141,11 @@ Usage: typings <command>
 Commands:
 ${wrap(Object.keys(aliases).sort().join(', '))}
 
-typings <command> -h   Get help for <command>
-typings <command> -V   Enable verbose logging
+typings <command> -h     Get help for <command>
+typings <command> -V     Enable verbose logging
 
-typings --version      Print the CLI version
+typings --version        Print the CLI version
+  [--log-level] <level>  Set the log level (E.g. "debug", info", "warn", "error", "silent")
 
 typings@${pkg.version} ${join(__dirname, '..')}
 `)

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -42,7 +42,7 @@ const unicodeConfig = process.env.TYPINGS_CONFIG_UNICODE || process.env.NPM_CONF
 
 const argv = minimist<Argv>(process.argv.slice(2), {
   boolean: ['version', 'save', 'saveDev', 'savePeer', 'global', 'verbose', 'production', 'unicode'],
-  string: ['cwd', 'out', 'name', 'source', 'offset', 'limit', 'sort', 'logLevel'],
+  string: ['cwd', 'out', 'name', 'source', 'offset', 'limit', 'sort', 'loglevel'],
   alias: {
     global: ['G'],
     version: ['v'],
@@ -65,10 +65,11 @@ function isTrue (value: string) {
 
 const cwd = argv.cwd ? resolve(argv.cwd) : process.cwd()
 const emitter: Emitter = new EventEmitter()
+const args: Args = extend(argv, { emitter, cwd })
+
 if (argv.loglevel) {
   setLogLevel(argv.loglevel)
 }
-const args: Args = extend(argv, { emitter, cwd })
 
 // Notify the user of updates.
 updateNotifier({ pkg }).notify()

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -65,7 +65,9 @@ function isTrue (value: string) {
 
 const cwd = argv.cwd ? resolve(argv.cwd) : process.cwd()
 const emitter: Emitter = new EventEmitter()
-const logLevel: number = argv.loglevel ? setLogLevel(argv.loglevel) : 0
+if (argv.loglevel) {
+  setLogLevel(argv.loglevel)
+}
 const args: Args = extend(argv, { emitter, cwd })
 
 // Notify the user of updates.

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -8,7 +8,7 @@ import chalk = require('chalk')
 import updateNotifier = require('update-notifier')
 import extend = require('xtend')
 import { EventEmitter } from 'events'
-import { handle, logWarning, logInfo, setLogLevel } from './support/cli'
+import { handle, logWarning, logInfo, setLoglevel } from './support/cli'
 import { Emitter } from 'typings-core'
 import { aliases } from './aliases'
 
@@ -68,7 +68,7 @@ const emitter: Emitter = new EventEmitter()
 const args: Args = extend(argv, { emitter, cwd })
 
 if (argv.loglevel) {
-  setLogLevel(argv.loglevel)
+  setLoglevel(argv.loglevel)
 }
 
 // Notify the user of updates.
@@ -144,11 +144,11 @@ Usage: typings <command>
 Commands:
 ${wrap(Object.keys(aliases).sort().join(', '))}
 
-typings <command> -h     Get help for <command>
-typings <command> -V     Enable verbose logging
+typings <command> -h    Get help for <command>
+typings <command> -V    Enable verbose logging
 
-typings --version        Print the CLI version
-  [--log-level] <level>  Set the log level (E.g. "debug", info", "warn", "error", "silent")
+typings --version       Print the CLI version
+  [--loglevel] <level>  Set the log level ("debug", info", "warn", "error" or "silent")
 
 typings@${pkg.version} ${join(__dirname, '..')}
 `)

--- a/src/support/cli.ts
+++ b/src/support/cli.ts
@@ -28,6 +28,43 @@ function formatLine (color: Function, type: string, line: string, prefix?: strin
 }
 
 /**
+ * Available log levels.
+ */
+let logLevels: LogLevels = {
+    debug: 0,
+    info: 1,
+    warn: 2,
+    error: 3,
+    silent: 4
+}
+interface LogLevels {
+    debug: number
+    info: number
+    warn: number
+    error: number
+    silent: number
+    [key: string]: number
+}
+
+/**
+ * Current log level.  Defaults to emit all.
+ */
+let logLevel: number = logLevels.info
+
+/**
+ * Set the level of logs to emit.
+ */
+export function setLogLevel(level: string): number {
+    let match = logLevels[level]
+    if (!match && match !== logLevels.debug) {
+        logError(`invalid log level (options are ${Object.keys(logLevels).join(', ')})`)
+    } else {
+        logLevel = match
+    }
+    return logLevel
+}
+
+/**
  * Log an info message.
  */
 export function logInfo (message: string, prefix?: string) {
@@ -35,7 +72,9 @@ export function logInfo (message: string, prefix?: string) {
     return formatLine(chalk.bgBlack.cyan, 'INFO', line, prefix)
   }).join('\n')
 
-  log(output)
+  if (logLevel <= logLevels.info) {
+    log(output)
+  }
 }
 
 /**
@@ -46,7 +85,9 @@ export function logWarning (message: string, prefix?: string) {
     return formatLine(chalk.bgYellow.black, 'WARN', line, prefix)
   }).join('\n')
 
-  log(output)
+  if (logLevel <= logLevels.warn) {
+    log(output)
+  }
 }
 
 /**
@@ -57,7 +98,9 @@ export function logError (message: string, prefix?: string) {
     return formatLine(chalk.bgBlack.red, 'ERR!', line, prefix)
   }).join('\n')
 
-  log(output)
+  if (logLevel <= logLevels.error) {
+    log(output)
+  }
 }
 
 /**

--- a/src/support/cli.ts
+++ b/src/support/cli.ts
@@ -47,7 +47,7 @@ let loglevel: number = loglevels['info']
 /**
  * Set the level of logs to emit.
  */
-export function setLogLevel(level: string): number {
+export function setLoglevel(level: string): number {
   if (!loglevels.hasOwnProperty(level)) {
     logError(`invalid log level (options are ${listify(Object.keys(loglevels))})`)
     return

--- a/src/support/cli.ts
+++ b/src/support/cli.ts
@@ -63,11 +63,11 @@ export function logInfo (message: string, prefix?: string) {
   if (loglevel > loglevels['info']) {
     return
   }
-  
+
   const output = message.split(/\r?\n/g).map(line => {
     return formatLine(chalk.bgBlack.cyan, 'INFO', line, prefix)
   }).join('\n')
-  
+
   log(output)
 }
 
@@ -78,11 +78,11 @@ export function logWarning (message: string, prefix?: string) {
   if (loglevel > loglevels['warn']) {
     return
   }
-  
+
   const output = message.split(/\r?\n/g).map(line => {
     return formatLine(chalk.bgYellow.black, 'WARN', line, prefix)
   }).join('\n')
-  
+
   log(output)
 }
 
@@ -93,11 +93,11 @@ export function logError (message: string, prefix?: string) {
   if (loglevel > loglevels['error']) {
     return
   }
-  
+
   const output = message.split(/\r?\n/g).map(line => {
     return formatLine(chalk.bgBlack.red, 'ERR!', line, prefix)
   }).join('\n')
-  
+
   log(output)
 }
 

--- a/src/support/cli.ts
+++ b/src/support/cli.ts
@@ -1,9 +1,9 @@
 import chalk = require('chalk')
 import Promise = require('any-promise')
 import archy = require('archy')
+import listify = require('listify')
 import * as os from 'os'
 import { DependencyTree, DependencyBranch } from 'typings-core'
-import * as listify from 'listify'
 
 const pkg = require('../../package.json')
 
@@ -40,7 +40,7 @@ const loglevels: { [key: string]: number } = {
 }
 
 /**
- * Current log level.  Defaults to emit all.
+ * Current logging level.
  */
 let loglevel: number = loglevels['info']
 
@@ -52,6 +52,7 @@ export function setLogLevel(level: string): number {
         logError(`invalid log level (options are ${listify(Object.keys(loglevels))})`)
         return
     }
+
     return (loglevel = loglevels[level])
 }
 
@@ -62,9 +63,11 @@ export function logInfo (message: string, prefix?: string) {
   if (loglevel > loglevels['info']) {
     return
   }
+  
   const output = message.split(/\r?\n/g).map(line => {
     return formatLine(chalk.bgBlack.cyan, 'INFO', line, prefix)
   }).join('\n')
+  
   log(output)
 }
 
@@ -75,9 +78,11 @@ export function logWarning (message: string, prefix?: string) {
   if (loglevel > loglevels['warn']) {
     return
   }
+  
   const output = message.split(/\r?\n/g).map(line => {
     return formatLine(chalk.bgYellow.black, 'WARN', line, prefix)
   }).join('\n')
+  
   log(output)
 }
 
@@ -88,9 +93,11 @@ export function logError (message: string, prefix?: string) {
   if (loglevel > loglevels['error']) {
     return
   }
+  
   const output = message.split(/\r?\n/g).map(line => {
     return formatLine(chalk.bgBlack.red, 'ERR!', line, prefix)
   }).join('\n')
+  
   log(output)
 }
 
@@ -116,11 +123,11 @@ export function handleError (error: Error, options: PrintOptions): any {
   }
 
   if (options.verbose && error.stack) {
-    log('')
+    logError('')
     logError(error.stack, 'stack')
   }
 
-  log('')
+  logError('')
   logError(process.cwd(), 'cwd')
   logError(`${os.type()} ${os.release()}`, 'system')
   logError(process.argv.map(arg => JSON.stringify(arg)).join(' '), 'command')
@@ -131,7 +138,7 @@ export function handleError (error: Error, options: PrintOptions): any {
     logError((error as any).code, 'code')
   }
 
-  log('')
+  logError('')
   logError('If you need help, you may report this error at:')
   logError(`  <https://github.com/typings/typings/issues>`)
 

--- a/src/support/cli.ts
+++ b/src/support/cli.ts
@@ -3,6 +3,7 @@ import Promise = require('any-promise')
 import archy = require('archy')
 import * as os from 'os'
 import { DependencyTree, DependencyBranch } from 'typings-core'
+import * as listify from 'listify'
 
 const pkg = require('../../package.json')
 
@@ -30,77 +31,67 @@ function formatLine (color: Function, type: string, line: string, prefix?: strin
 /**
  * Available log levels.
  */
-let logLevels: LogLevels = {
-    debug: 0,
-    info: 1,
-    warn: 2,
-    error: 3,
-    silent: 4
-}
-interface LogLevels {
-    debug: number
-    info: number
-    warn: number
-    error: number
-    silent: number
-    [key: string]: number
+const loglevels: { [key: string]: number } = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  silent: 4
 }
 
 /**
  * Current log level.  Defaults to emit all.
  */
-let logLevel: number = logLevels.info
+let loglevel: number = loglevels['info']
 
 /**
  * Set the level of logs to emit.
  */
 export function setLogLevel(level: string): number {
-    let match = logLevels[level]
-    if (!match && match !== logLevels.debug) {
-        logError(`invalid log level (options are ${Object.keys(logLevels).join(', ')})`)
-    } else {
-        logLevel = match
+    if (!loglevels.hasOwnProperty(level)) {
+        logError(`invalid log level (options are ${listify(Object.keys(loglevels))})`)
+        return
     }
-    return logLevel
+    return (loglevel = loglevels[level])
 }
 
 /**
  * Log an info message.
  */
 export function logInfo (message: string, prefix?: string) {
+  if (loglevel > loglevels['info']) {
+    return
+  }
   const output = message.split(/\r?\n/g).map(line => {
     return formatLine(chalk.bgBlack.cyan, 'INFO', line, prefix)
   }).join('\n')
-
-  if (logLevel <= logLevels.info) {
-    log(output)
-  }
+  log(output)
 }
 
 /**
  * Log a warning message.
  */
 export function logWarning (message: string, prefix?: string) {
+  if (loglevel > loglevels['warn']) {
+    return
+  }
   const output = message.split(/\r?\n/g).map(line => {
     return formatLine(chalk.bgYellow.black, 'WARN', line, prefix)
   }).join('\n')
-
-  if (logLevel <= logLevels.warn) {
-    log(output)
-  }
+  log(output)
 }
 
 /**
  * Log an error message.
  */
 export function logError (message: string, prefix?: string) {
+  if (loglevel > loglevels['error']) {
+    return
+  }
   const output = message.split(/\r?\n/g).map(line => {
     return formatLine(chalk.bgBlack.red, 'ERR!', line, prefix)
   }).join('\n')
-
-  if (logLevel <= logLevels.error) {
-    log(output)
-  }
+  log(output)
 }
 
 /**

--- a/src/support/cli.ts
+++ b/src/support/cli.ts
@@ -48,12 +48,12 @@ let loglevel: number = loglevels['info']
  * Set the level of logs to emit.
  */
 export function setLogLevel(level: string): number {
-    if (!loglevels.hasOwnProperty(level)) {
-        logError(`invalid log level (options are ${listify(Object.keys(loglevels))})`)
-        return
-    }
+  if (!loglevels.hasOwnProperty(level)) {
+    logError(`invalid log level (options are ${listify(Object.keys(loglevels))})`)
+    return
+  }
 
-    return (loglevel = loglevels[level])
+  return (loglevel = loglevels[level])
 }
 
 /**


### PR DESCRIPTION
1. Adds a check in bin for whether loglevel is passed in, or defaults to `debug`.
2. Warns if invalid value is passed in and stays in debug if so.
3. Allows setting `debug`, `info`, `warn`, `error`, and `silent`
