### PR TITLE
- Document effect of NODE_ENV=production on the 'typings install' com…

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,7 +39,10 @@ Options:
   [--global|-G]     Install and persist as a global definition
     [-SG]           Persist to "globalDependencies"
     [-DG]           Persist to "globalDevDependencies"
-  [--production]    Install only production dependencies (omits dev dependencies)
+  [--production]    Install only production dependencies (omits dev dependencies) and
+                    is implictly set when environment variable NODE_ENV=production
+  [--no-production] Install production and dev dependencies (overrides environment
+                    variable NODE_ENV=production)
 
 Aliases: i, in
 ```

--- a/src/bin-install.ts
+++ b/src/bin-install.ts
@@ -35,7 +35,10 @@ Options:
   [--global|-G]     Install and persist as a global definition
     [-SG]           Persist to "globalDependencies"
     [-DG]           Persist to "globalDevDependencies"
-  [--production]    Install only production dependencies (omits dev dependencies)
+  [--production]    Install only production dependencies (omits dev dependencies) and 
+                    is implictly set when environment variable NODE_ENV=production
+  [--no-production] Install production and dev dependencies (overrides environment 
+                    variable NODE_ENV=production)
 
 Aliases: i, in
 `


### PR DESCRIPTION
Pull request related to issue #720 :

- Document the existence of the `--no-production` flag for the `typings install` command
- Document the link between `NODE_ENV=production` and the `--production` flag for the `typings install` command
