### PR TITLE
fix: Wait for process if no TTY is set, since the promise otherwise get aborted.

### DIFF
--- a/src/support/cli.ts
+++ b/src/support/cli.ts
@@ -134,9 +134,8 @@ export function render () {
     }
 
     logUpdate(truncate(status, (process.stdout as any).columns))
-
-    statusTimeout = setTimeout(render, 50)
   }
+  statusTimeout = setTimeout(render, 50)
 }
 
 /**


### PR DESCRIPTION
When calling `typings` without an tty, for example with a pipe or file redirection, typings is aborting all network traffic without any message to the user. The reason is that the spinner is only enabled if `process.stdout.isTTY` set, steps to reproduce:
* Have a valid typings file with at least one typing.
* Call: `typings install >> test.txt`

Afterwards, test.txt will be empty and no typings installed.

Suggested fix: Add the timeout also, if there is no shell, then the process will waiting for the promise to be resolved/rejected.